### PR TITLE
[codex] update process-explorer release dependencies

### DIFF
--- a/packages/app/dependencies.json
+++ b/packages/app/dependencies.json
@@ -32,6 +32,17 @@
       "toFolder": "packages/shared-process"
     },
     {
+      "fromRepo": "process-explorer",
+      "toRepo": "lvce-editor",
+      "toFolder": "packages/shared-process"
+    },
+    {
+      "fromRepo": "process-explorer",
+      "toRepo": "lvce-editor",
+      "toFolder": "packages/renderer-worker",
+      "asName": "process-explorer-worker"
+    },
+    {
       "fromRepo": "preview-sandbox-worker",
       "toRepo": "lvce-editor",
       "toFolder": "packages/renderer-worker"

--- a/packages/app/test/handleReleaseReleased.test.ts
+++ b/packages/app/test/handleReleaseReleased.test.ts
@@ -18,6 +18,8 @@ jest.unstable_mockModule('../src/getDependenciesConfig.ts', () => ({
     dependencies: [
       { fromRepo: 'lvce-editor', toRepo: 'editor-worker', toFolder: 'packages/server' },
       { fromRepo: 'test-worker', toRepo: 'lvce-editor', toFolder: 'packages/renderer-worker' },
+      { fromRepo: 'process-explorer', toRepo: 'lvce-editor', toFolder: 'packages/shared-process' },
+      { asName: 'process-explorer-worker', fromRepo: 'process-explorer', toRepo: 'lvce-editor', toFolder: 'packages/renderer-worker' },
     ],
   }),
 }))
@@ -124,6 +126,37 @@ test('dispatches update-specific-dependency migrations for matching release depe
     migrationId: '/migrations2/update-specific-dependency',
     migrationOptions: {
       fromRepo: 'test-worker',
+      tagName: 'v1.0.0',
+      toFolder: 'packages/renderer-worker',
+      toRepo: 'lvce-editor',
+    },
+    targetRepository: 'lvce-editor/lvce-editor',
+  })
+})
+
+test('dispatches process-explorer updates for shared-process and renderer-worker packages', async () => {
+  const context = createContext('published', 'process-explorer')
+  const app = {} as any
+
+  await handleReleaseReleased(context, app)
+
+  expect(mockDispatchMigrationWorkflow).toHaveBeenCalledWith({
+    app,
+    migrationId: '/migrations2/update-specific-dependency',
+    migrationOptions: {
+      fromRepo: 'process-explorer',
+      tagName: 'v1.0.0',
+      toFolder: 'packages/shared-process',
+      toRepo: 'lvce-editor',
+    },
+    targetRepository: 'lvce-editor/lvce-editor',
+  })
+  expect(mockDispatchMigrationWorkflow).toHaveBeenCalledWith({
+    app,
+    migrationId: '/migrations2/update-specific-dependency',
+    migrationOptions: {
+      asName: 'process-explorer-worker',
+      fromRepo: 'process-explorer',
       tagName: 'v1.0.0',
       toFolder: 'packages/renderer-worker',
       toRepo: 'lvce-editor',


### PR DESCRIPTION
## Summary

Update the release dependency configuration so a `process-explorer` release automatically dispatches dependency update migrations for both relevant `lvce-editor` packages.

## Impact

A `process-explorer` release now updates `@lvce-editor/process-explorer` in `packages/shared-process` and `@lvce-editor/process-explorer-worker` in `packages/renderer-worker`.

## Validation

- `npm test -- --runTestsByPath test/handleReleaseReleased.test.ts` from `packages/app`
- `npx prettier --check packages/app/dependencies.json packages/app/test/handleReleaseReleased.test.ts`