### PR TITLE
fix: flush planned release batches

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -24,6 +24,55 @@ import { getDependenciesConfig } from './getDependenciesConfig.ts'
 
 const dependenciesConfig = getDependenciesConfig()
 const dependencies = dependenciesConfig.dependencies
+const handledReleases = new Set<string>()
+const handledReleaseTtl = 10 * 60 * 1000
+const handledReleaseTimeouts = new Map<string, NodeJS.Timeout>()
+
+const getReleaseKey = (context: Context<'release'>): string => {
+  const { payload } = context
+  return `${payload.repository.full_name || `${payload.repository.owner.login}/${payload.repository.name}`}@${payload.release.id || payload.release.tag_name}`
+}
+
+const markReleaseHandled = (context: Context<'release'>): boolean => {
+  const key = getReleaseKey(context)
+  if (handledReleases.has(key)) {
+    return false
+  }
+  handledReleases.add(key)
+  const timeout = setTimeout(() => {
+    handledReleases.delete(key)
+    handledReleaseTimeouts.delete(key)
+  }, handledReleaseTtl).unref()
+  handledReleaseTimeouts.set(key, timeout)
+  return true
+}
+
+export const resetHandledReleases = (): void => {
+  for (const timeout of handledReleaseTimeouts.values()) {
+    clearTimeout(timeout)
+  }
+  handledReleaseTimeouts.clear()
+  handledReleases.clear()
+}
+
+const dispatchDependencyUpdate = async (app: Probot, dependency: any, owner: string, tagName: string): Promise<void> => {
+  try {
+    await dispatchMigrationWorkflow({
+      app,
+      migrationId: '/migrations2/update-specific-dependency',
+      migrationOptions: {
+        ...(dependency.asName && { asName: dependency.asName }),
+        fromRepo: dependency.fromRepo,
+        tagName,
+        toFolder: dependency.toFolder,
+        toRepo: dependency.toRepo,
+      },
+      targetRepository: `${owner}/${dependency.toRepo}`,
+    })
+  } catch (error) {
+    captureException(error as Error)
+  }
+}
 
 const updateRepositoryDependencies = async (context: Context<'release'>, app?: Probot) => {
   if (!app) {
@@ -36,8 +85,10 @@ const updateRepositoryDependencies = async (context: Context<'release'>, app?: P
   const matchingDependencies = dependencies.filter((dependency) => dependency.fromRepo === releasedRepo)
   const repository = `${owner}/${releasedRepo}`
   if (PlannedReleaseBatch.isPlannedReleasePending(repository, tagName)) {
+    const pendingDependencies = matchingDependencies.filter((dependency) => dependency.toRepo === 'lvce-editor')
+    const immediateDependencies = matchingDependencies.filter((dependency) => dependency.toRepo !== 'lvce-editor')
     PlannedReleaseBatch.addPendingDependencyUpdates(
-      matchingDependencies.map((dependency) => ({
+      pendingDependencies.map((dependency) => ({
         ...(dependency.asName && { asName: dependency.asName }),
         fromRepo: dependency.fromRepo,
         tagName,
@@ -45,28 +96,10 @@ const updateRepositoryDependencies = async (context: Context<'release'>, app?: P
         toRepo: dependency.toRepo,
       })),
     )
+    await Promise.all(immediateDependencies.map((dependency) => dispatchDependencyUpdate(app, dependency, owner, tagName)))
     return
   }
-  await Promise.all(
-    matchingDependencies.map(async (dependency) => {
-      try {
-        await dispatchMigrationWorkflow({
-          app,
-          migrationId: '/migrations2/update-specific-dependency',
-          migrationOptions: {
-            ...(dependency.asName && { asName: dependency.asName }),
-            fromRepo: dependency.fromRepo,
-            tagName,
-            toFolder: dependency.toFolder,
-            toRepo: dependency.toRepo,
-          },
-          targetRepository: `${owner}/${dependency.toRepo}`,
-        })
-      } catch (error) {
-        captureException(error as Error)
-      }
-    }),
-  )
+  await Promise.all(matchingDependencies.map((dependency) => dispatchDependencyUpdate(app, dependency, owner, tagName)))
 }
 
 const updateWebsiteConfig = async (context: Context<'release'>, app?: Probot) => {
@@ -103,6 +136,9 @@ export const shouldHandleRelease = (context: Context<'release'>): boolean => {
 
 export const handleReleaseReleased = async (context: Context<'release'>, app?: Probot) => {
   if (!shouldHandleRelease(context)) {
+    return
+  }
+  if (!markReleaseHandled(context)) {
     return
   }
   await Promise.all([updateBuiltinExtensions(context), updateRepositoryDependencies(context, app), updateWebsiteConfig(context, app)])

--- a/packages/app/src/parts/HandleMigrationWorkflowRun/HandleMigrationWorkflowRun.ts
+++ b/packages/app/src/parts/HandleMigrationWorkflowRun/HandleMigrationWorkflowRun.ts
@@ -234,7 +234,9 @@ export const createHandleMigrationWorkflowRun = (options: Readonly<CreateHandleM
             captureException(error as Error)
           }
         }
-        PlannedReleaseBatch.startPlannedReleaseBatch(plannedReleases)
+        PlannedReleaseBatch.startPlannedReleaseBatch(plannedReleases, async (batches) => {
+          await dispatchPendingDependencyUpdateBatches(logger, batches)
+        })
         return
       }
       if (artifact.changedFiles.length === 0 && (!artifact.manifest.repoCommands || artifact.manifest.repoCommands.length === 0)) {

--- a/packages/app/src/parts/PlannedReleaseBatch/PlannedReleaseBatch.ts
+++ b/packages/app/src/parts/PlannedReleaseBatch/PlannedReleaseBatch.ts
@@ -17,13 +17,18 @@ export interface PendingDependencyUpdateBatch {
   readonly updates: readonly PendingDependencyUpdate[]
 }
 
+export type PlannedReleaseBatchTimeoutHandler = (batches: readonly PendingDependencyUpdateBatch[]) => void | Promise<void>
+
 interface PlannedReleaseBatchState {
   readonly completedPlannedReleases: Set<string>
   readonly pendingDependencyUpdates: PendingDependencyUpdate[]
   readonly pendingPlannedReleases: Map<string, PlannedRelease>
+  readonly timeout?: NodeJS.Timeout
 }
 
 let state: PlannedReleaseBatchState | undefined
+
+export const PlannedReleaseBatchTimeout = 5 * 60 * 1000
 
 const getReleaseKey = (repository: string, tagName: string): string => {
   return `${repository}@${tagName}`
@@ -35,18 +40,36 @@ const getRepoName = (repository: string): string => {
 }
 
 export const resetPlannedReleaseBatch = (): void => {
+  if (state?.timeout) {
+    clearTimeout(state.timeout)
+  }
   state = undefined
 }
 
-export const startPlannedReleaseBatch = (releases: readonly PlannedRelease[]): void => {
+export const startPlannedReleaseBatch = (
+  releases: readonly PlannedRelease[],
+  onTimeout?: PlannedReleaseBatchTimeoutHandler,
+  timeout = PlannedReleaseBatchTimeout,
+): void => {
+  resetPlannedReleaseBatch()
   const pendingPlannedReleases = new Map<string, PlannedRelease>()
   for (const release of releases) {
     pendingPlannedReleases.set(getReleaseKey(release.repository, release.tagName), release)
   }
+  const timeoutHandle =
+    onTimeout && pendingPlannedReleases.size > 0
+      ? setTimeout(() => {
+          const batches = flushPendingDependencyUpdateBatches()
+          if (batches.length > 0) {
+            void onTimeout(batches)
+          }
+        }, timeout)
+      : undefined
   state = {
     completedPlannedReleases: new Set(),
     pendingDependencyUpdates: [],
     pendingPlannedReleases,
+    ...(timeoutHandle && { timeout: timeoutHandle }),
   }
 }
 
@@ -61,6 +84,15 @@ export const addPendingDependencyUpdates = (updates: readonly PendingDependencyU
   state.pendingDependencyUpdates.push(...updates)
 }
 
+export const flushPendingDependencyUpdateBatches = (): readonly PendingDependencyUpdateBatch[] => {
+  if (!state) {
+    return []
+  }
+  const batches = getPendingDependencyUpdateBatches()
+  resetPlannedReleaseBatch()
+  return batches
+}
+
 export const markPlannedReleaseCompleted = (repository: string, tagName: string): readonly PendingDependencyUpdateBatch[] => {
   if (!state) {
     return []
@@ -73,9 +105,7 @@ export const markPlannedReleaseCompleted = (repository: string, tagName: string)
   if (state.completedPlannedReleases.size !== state.pendingPlannedReleases.size) {
     return []
   }
-  const batches = getPendingDependencyUpdateBatches()
-  resetPlannedReleaseBatch()
-  return batches
+  return flushPendingDependencyUpdateBatches()
 }
 
 const getPendingDependencyUpdateBatches = (): readonly PendingDependencyUpdateBatch[] => {

--- a/packages/app/test/HandleMigrationWorkflowRun.test.ts
+++ b/packages/app/test/HandleMigrationWorkflowRun.test.ts
@@ -742,6 +742,142 @@ test('dispatches pending dependency updates after all planned release workflows 
   })
 })
 
+test('dispatches pending dependency updates when planned release batch times out', async () => {
+  jest.useFakeTimers()
+  try {
+    const downloadMigrationArtifact = (jest.fn() as any).mockResolvedValue({
+      changedFiles: [],
+      manifest: {
+        data: {
+          releasePlan: {
+            entries: [
+              {
+                newTag: 'v1.1.0',
+                repository: 'lvce-editor/activity-bar-worker',
+                targetSha: 'main-sha',
+                upgrade: true,
+              },
+              {
+                newTag: 'v2.1.0',
+                repository: 'lvce-editor/status-bar-worker',
+                targetSha: 'main-sha',
+                upgrade: true,
+              },
+            ],
+          },
+        },
+        migrationId: '/migrations2/plan-org-release-tags',
+        requestId: 'nightly-1',
+        status: 'success',
+        targetRepository: 'lvce-editor/helper-bot',
+      },
+    })
+    const invokeGithubWorker = (jest.fn() as any).mockResolvedValue({
+      data: {
+        message: 'Created tag',
+        status: 'created',
+      },
+      type: 'success',
+    })
+    const dispatchMigrationWorkflow = (jest.fn() as any).mockResolvedValue({
+      requestId: 'request-dependencies',
+    })
+    const getRepoInstallation = (jest.fn() as any).mockResolvedValue({
+      data: {
+        id: 77,
+      },
+    })
+    const auth = (jest.fn() as any).mockResolvedValue({
+      token: 'installation-token',
+    })
+    const app: any = {
+      auth: (jest.fn() as any)
+        .mockResolvedValueOnce({
+          rest: {
+            apps: {
+              getRepoInstallation,
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          auth,
+        })
+        .mockResolvedValueOnce({
+          rest: {
+            apps: {
+              getRepoInstallation,
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          auth,
+        }) as any,
+    }
+    const context: any = {
+      log: {
+        error: errorSpy,
+        info: infoSpy,
+        warn: warnSpy,
+      },
+      octokit: {},
+      payload: {
+        action: 'completed',
+        repository: {
+          name: 'helper-bot',
+          owner: {
+            login: 'lvce-editor',
+          },
+        },
+        workflow_run: {
+          event: 'workflow_dispatch',
+          head_branch: 'main',
+          id: 123,
+          path: MIGRATION_WORKFLOW_PATH,
+        },
+      },
+    }
+
+    const { createHandleMigrationWorkflowRun } = await import('../src/parts/HandleMigrationWorkflowRun/HandleMigrationWorkflowRun.ts')
+    const handleMigrationWorkflowRun = createHandleMigrationWorkflowRun({
+      app,
+      dispatchMigrationWorkflow,
+      downloadMigrationArtifact,
+      invokeGithubWorker,
+    })
+
+    await handleMigrationWorkflowRun(context)
+    PlannedReleaseBatch.addPendingDependencyUpdates([
+      {
+        fromRepo: 'activity-bar-worker',
+        tagName: 'v1.1.0',
+        toFolder: 'packages/renderer-worker',
+        toRepo: 'lvce-editor',
+      },
+    ])
+
+    await jest.advanceTimersByTimeAsync(PlannedReleaseBatch.PlannedReleaseBatchTimeout)
+
+    expect(dispatchMigrationWorkflow).toHaveBeenCalledWith({
+      app,
+      migrationId: '/migrations2/update-specific-dependencies',
+      migrationOptions: {
+        toRepo: 'lvce-editor',
+        updates: [
+          {
+            fromRepo: 'activity-bar-worker',
+            tagName: 'v1.1.0',
+            toFolder: 'packages/renderer-worker',
+            toRepo: 'lvce-editor',
+          },
+        ],
+      },
+      targetRepository: 'lvce-editor/lvce-editor',
+    })
+  } finally {
+    jest.useRealTimers()
+  }
+})
+
 test('ignores dry run org release plan artifacts without creating tag refs', async () => {
   const downloadMigrationArtifact = (jest.fn() as any).mockResolvedValue({
     changedFiles: [],

--- a/packages/app/test/handleReleaseReleased.test.ts
+++ b/packages/app/test/handleReleaseReleased.test.ts
@@ -32,7 +32,7 @@ jest.unstable_mockModule('../src/errorHandling.ts', () => ({
   captureException: mockCaptureException,
 }))
 
-const { handleReleaseReleased, shouldHandleRelease } = await import('../src/index.ts')
+const { handleReleaseReleased, resetHandledReleases, shouldHandleRelease } = await import('../src/index.ts')
 const PlannedReleaseBatch = await import('../src/parts/PlannedReleaseBatch/PlannedReleaseBatch.ts')
 
 beforeEach(() => {
@@ -46,6 +46,7 @@ beforeEach(() => {
   mockUpdateDependencies.mockClear()
   mockDispatchMigrationWorkflow.mockClear()
   PlannedReleaseBatch.resetPlannedReleaseBatch()
+  resetHandledReleases()
 })
 
 const createContext = (action: string, repositoryName: string, release: Record<string, unknown> = {}) => {
@@ -163,6 +164,43 @@ test('collects matching planned release dependency updates instead of dispatchin
       ],
     },
   ])
+})
+
+test('dispatches non-lvce-editor target dependency updates immediately during planned release batches', async () => {
+  PlannedReleaseBatch.startPlannedReleaseBatch([
+    {
+      repository: 'lvce-editor/lvce-editor',
+      tagName: 'v1.0.0',
+    },
+  ])
+  const context = createContext('published', 'lvce-editor')
+  const app = {} as any
+
+  await handleReleaseReleased(context, app)
+
+  expect(mockDispatchMigrationWorkflow).toHaveBeenCalledWith({
+    app,
+    migrationId: '/migrations2/update-specific-dependency',
+    migrationOptions: {
+      fromRepo: 'lvce-editor',
+      tagName: 'v1.0.0',
+      toFolder: 'packages/server',
+      toRepo: 'editor-worker',
+    },
+    targetRepository: 'lvce-editor/editor-worker',
+  })
+})
+
+test('ignores duplicate release webhooks for the same release', async () => {
+  const app = {} as any
+  const context = createContext('created', 'test-worker', { id: 123 })
+  const duplicateContext = createContext('published', 'test-worker', { id: 123 })
+
+  await handleReleaseReleased(context, app)
+  await handleReleaseReleased(duplicateContext, app)
+
+  expect(mockUpdateBuiltinExtensions).toHaveBeenCalledTimes(1)
+  expect(mockDispatchMigrationWorkflow).toHaveBeenCalledTimes(1)
 })
 
 test('dispatches process-explorer updates for shared-process and renderer-worker packages', async () => {

--- a/packages/app/test/index.test.ts
+++ b/packages/app/test/index.test.ts
@@ -34,6 +34,7 @@ cDIUGO9eluOat3V1vIlRyZ4BJsL/YbrVh8HfZ4+XD5vn37krunyR8HfY0GeWpFTH
 
 beforeEach(async () => {
   nock.disableNetConnect()
+  myProbotApp.resetHandledReleases()
   probot = new Probot({
     appId: 123,
     privateKey,


### PR DESCRIPTION
Fix planned release dependency batching after #670.\n\n- Deduplicate repeated release webhook deliveries before creating update PRs.\n- Only hold batched dependency updates targeting lvce-editor/lvce-editor.\n- Flush pending planned-release batches after 5 minutes so updates do not wait forever.