### PR TITLE
fix: support command substitution in dependency exclusion migration

### DIFF
--- a/packages/migrations/src/parts/ExcludeDependencyFromUpdates/ExcludeDependencyFromUpdates.ts
+++ b/packages/migrations/src/parts/ExcludeDependencyFromUpdates/ExcludeDependencyFromUpdates.ts
@@ -8,7 +8,7 @@ export interface ExcludeDependencyFromUpdatesOptions extends BaseMigrationOption
   dependencyName: string
 }
 
-const ncuCommandRegex = /OUTPUT=`ncu -u(?<args>.*?)`/g
+const ncuCommandRegex = /OUTPUT=(?<quote>`|\$\()ncu -u(?<args>.*?)(?<end>[`)])/g
 const excludedDependencyRegex = /(?:^|\s)-x\s+(?<dependency>[^\s]+)/g
 const dependencyNameRegex = /^@?[a-z-]+(?:\/[a-z-]+)?$/
 
@@ -27,6 +27,12 @@ const addDependencyExclusion = (ncuArgs: string, dependencyName: string): string
     return ` -x ${dependencyName}`
   }
   return `${ncuArgs} -x ${dependencyName}`
+}
+
+const getUpdatedOutputCommand = (match: RegExpMatchArray, updatedArgs: string): string => {
+  const quote = match.groups?.quote || '`'
+  const end = quote === '$(' ? ')' : '`'
+  return `OUTPUT=${quote}ncu -u${updatedArgs}${end}`
 }
 
 const computeExcludeDependencyFromUpdatesContent = (
@@ -54,7 +60,7 @@ const computeExcludeDependencyFromUpdatesContent = (
       continue
     }
     const updatedArgs = addDependencyExclusion(ncuArgs, dependencyName)
-    newContent = newContent.replace(match[0], () => `OUTPUT=\`ncu -u${updatedArgs}\``)
+    newContent = newContent.replace(match[0], () => getUpdatedOutputCommand(match, updatedArgs))
     hasChanges = true
   }
 

--- a/packages/migrations/test/ExcludeDependencyFromUpdates.test.ts
+++ b/packages/migrations/test/ExcludeDependencyFromUpdates.test.ts
@@ -103,6 +103,36 @@ function updateDependencies {
   })
 })
 
+test('adds dependency exclusion to ncu command with dollar paren command substitution', async () => {
+  const content = `#!/bin/bash
+
+function updateDependencies {
+  OUTPUT=$(ncu -u -x @types/node -x lerna -x @babel/preset-typescript)
+}
+`
+
+  const result = await excludeDependencyFromUpdates(createOptions(content, 'typescript'))
+
+  expect(result).toEqual({
+    branchName: 'feature/exclude-typescript-from-updates',
+    changedFiles: [
+      {
+        content: `#!/bin/bash
+
+function updateDependencies {
+  OUTPUT=$(ncu -u -x @types/node -x lerna -x @babel/preset-typescript -x typescript)
+}
+`,
+        path: 'scripts/update-dependencies.sh',
+      },
+    ],
+    commitMessage: 'ci: exclude typescript from dependency updates',
+    pullRequestTitle: 'ci: exclude typescript from dependency updates',
+    status: 'success',
+    statusCode: 201,
+  })
+})
+
 test('returns empty result when dependency is already excluded', async () => {
   const content = `#!/bin/bash
 


### PR DESCRIPTION
Updates the dependency exclusion migration so it handles both backtick and dollar-paren ncu command substitution forms.